### PR TITLE
fix: include app root_path in dashboard static file URLs

### DIFF
--- a/fastapi_profiler/profiler.py
+++ b/fastapi_profiler/profiler.py
@@ -66,10 +66,15 @@ class Profiler:
         with open(template_path) as f:
             template = f.read()
 
-        # Pre-render the template
-        return template.replace(
-            "{{js_path}}", f"{self.dashboard_path}/static/js/dashboard.js"
-        ).replace("{{dashboard_path}}", self.dashboard_path)
+        # Pre-render the template with root_path support
+        root_path = getattr(self.app, "root_path", "").rstrip("/")
+
+        full_dashboard_path = f"{root_path}{self.dashboard_path}"
+        js_path = f"{full_dashboard_path}/static/js/dashboard.js"
+
+        return template.replace("{{js_path}}", js_path).replace(
+            "{{dashboard_path}}", full_dashboard_path
+        )
 
     def _render_dashboard(self):
         """Return the pre-rendered dashboard HTML."""


### PR DESCRIPTION
Static files failed to load when FastAPI app used custom root_path. Now correctly prepends rooth_path to all dashboard URLs.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
